### PR TITLE
add 2022/23 models

### DIFF
--- a/lib/ios/devices.rb
+++ b/lib/ios/devices.rb
@@ -92,6 +92,22 @@ module Ios
         Model.new(device_type, 'iPhone 13')
       when 'iPhone14,6'
         Model.new(device_type, 'iPhone SE', '3rd gen')
+      when 'iPhone14,7'
+        Model.new(device_type, 'iPhone 14')
+      when 'iPhone14,8'
+        Model.new(device_type, 'iPhone 14 Plus')
+      when 'iPhone15,2'
+        Model.new(device_type, 'iPhone 14 Pro')
+      when 'iPhone15,3'
+        Model.new(device_type, 'iPhone 14 Pro Max')
+      when 'iPhone15,4'
+        Model.new(device_type, 'iPhone 15')
+      when 'iPhone15,5'
+        Model.new(device_type, 'iPhone 15 Plus')
+      when 'iPhone16,1'
+        Model.new(device_type, 'iPhone 15 Pro')
+      when 'iPhone16,2'
+        Model.new(device_type, 'iPhone 15 Pro Max')
       when 'iPad1,1'
         Model.new(device_type, 'iPad')
       when 'iPad2,1'
@@ -224,6 +240,14 @@ module Ios
         Model.new(device_type, 'iPad mini 6', 'Wi-Fi')
       when 'iPad14,2'
         Model.new(device_type, 'iPad mini 6', 'Wi-Fi+LTE')
+      when 'iPad14,3'
+        Model.new(device_type, 'iPad Pro 11', '4th Gen, Wi-Fi')
+      when 'iPad14,4'
+        Model.new(device_type, 'iPad Pro 11', '4th Gen, Wi-Fi+LTE')
+      when 'iPad14,5'
+        Model.new(device_type, 'iPad Pro 12.9', '6th Gen, Wi-Fi')
+      when 'iPad14,6'
+        Model.new(device_type, 'iPad Pro 12.9', '6th Gen, Wi-Fi+LTE')
       when 'iPod1,1'
         Model.new(device_type, 'iPod touch')
       when 'iPod2,1'


### PR DESCRIPTION
from https://deviceatlas.com/resources/clientside/ios-hardware-identification but https://gist.github.com/adamawolf/3048717 is maybe updated more often than this gem but doesn't have the details like wifi vs cellular ipads like https://www.theiphonewiki.com/wiki/IPad_Pro_(12.9-inch)_(6th_generation)