### PR TITLE
Fix missing '"' in iPad names

### DIFF
--- a/lib/ios/devices.rb
+++ b/lib/ios/devices.rb
@@ -241,13 +241,13 @@ module Ios
       when 'iPad14,2'
         Model.new(device_type, 'iPad mini 6', 'Wi-Fi+LTE')
       when 'iPad14,3'
-        Model.new(device_type, 'iPad Pro 11', '4th Gen, Wi-Fi')
+        Model.new(device_type, 'iPad Pro 11"', '4th Gen, Wi-Fi')
       when 'iPad14,4'
-        Model.new(device_type, 'iPad Pro 11', '4th Gen, Wi-Fi+LTE')
+        Model.new(device_type, 'iPad Pro 11"', '4th Gen, Wi-Fi+LTE')
       when 'iPad14,5'
-        Model.new(device_type, 'iPad Pro 12.9', '6th Gen, Wi-Fi')
+        Model.new(device_type, 'iPad Pro 12.9"', '6th Gen, Wi-Fi')
       when 'iPad14,6'
-        Model.new(device_type, 'iPad Pro 12.9', '6th Gen, Wi-Fi+LTE')
+        Model.new(device_type, 'iPad Pro 12.9"', '6th Gen, Wi-Fi+LTE')
       when 'iPod1,1'
         Model.new(device_type, 'iPod touch')
       when 'iPod2,1'


### PR DESCRIPTION
A few of the iPad names are missing the "inches" symbol that is present in the others.