### PR TITLE
Add iPhone 17

### DIFF
--- a/lib/ios/devices.rb
+++ b/lib/ios/devices.rb
@@ -118,6 +118,16 @@ module Ios
         Model.new(device_type, 'iPhone 16')
       when 'iPhone17,4'
         Model.new(device_type, 'iPhone 16 Plus')
+      when 'iPhone17,5'
+        Model.new(device_type, 'iPhone 16e')
+      when 'iPhone18,1'
+        Model.new(device_type, 'iPhone 17 Pro')
+      when 'iPhone18,2'
+        Model.new(device_type, 'iPhone 17 Pro Max')
+      when 'iPhone18,3'
+        Model.new(device_type, 'iPhone 17')
+      when 'iPhone18,4'
+        Model.new(device_type, 'iPhone Air')
       when 'iPad1,1'
         Model.new(device_type, 'iPad')
       when 'iPad1,2'

--- a/lib/ios/devices/version.rb
+++ b/lib/ios/devices/version.rb
@@ -2,6 +2,6 @@
 
 module Ios
   module Devices
-    VERSION = '0.3.4'
+    VERSION = '0.3.5'
   end
 end


### PR DESCRIPTION
Adds the iPhone 17 models, used https://appledb.dev/device-selection/iPhone.html for the identifiers.

- I added iPhone 16e as well because I noticed it was missing